### PR TITLE
fix: delete config for removed rule

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -28,7 +28,6 @@ module.exports = {
         "jest/no-identical-title": "error",
         "jest/no-interpolation-in-snapshots": "error",
         "jest/no-jasmine-globals": "error",
-        "jest/no-jest-import": "error",
         "jest/no-mocks-import": "error",
         "jest/valid-describe-callback": "error",
         "jest/valid-expect": "error",


### PR DESCRIPTION
The rule [no-jest-import for eslint-plugin-jest was removed in v27](https://github.com/jest-community/eslint-plugin-jest/blob/main/CHANGELOG.md#2700-2022-08-28). Installing this config on a project results in "Definition for rule 'jest/no-jest-import' was not found" for each test file.

## Workarounds
The current workaround is to explicitly disable this rule in the project where this config is installed:

```json
{
  "rules": {
     "jest/no-jest-import": "off"
  }
}
```