### PR TITLE
feat: allow mutation on module.exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ module.exports = {
     "functional/no-conditional-statements": "off",
     "functional/prefer-immutable-types": "off",
     "functional/no-mixed-types": "off",
+    "functional/immutable-data": ["error", { ignoreIdentifierPattern: "^module.exports$" }],
     "no-console": ["error", { allow: ["error", "warn", "info"] }],
     "prettier/prettier": "error",
     "arrow-body-style": "off",


### PR DESCRIPTION
# Allow `module.exports`

## Issue

The linter complains about files that use `module.exports`, which is valid mutation in CommonJS projects. This can be disabled project by project, but this is something we never want to disallow, so it seems better to disable it in the configuration.

## Current Workaround

The same rule that we are adding to this config can be added at the project level, namely:

```json
{
  "rules": {
     "functional/immutable-data": [
        "error", 
        { 
           "ignoreIdentifierPattern": "^module.exports$" 
         }
     ],
  }
}
```

## Considerations

We may want add documentation as well that overriding this rule at the project level will disable this allowance, rather than extend it (I believe). 